### PR TITLE
NCAS-1538 Updating as per GCA rebranding

### DIFF
--- a/CCS_OCDS_Standards/CCS-OCDS_Schema.yaml
+++ b/CCS_OCDS_Standards/CCS-OCDS_Schema.yaml
@@ -120,7 +120,7 @@ components:
           description: 'The URI of this package that identifies it uniquely in the world. Recommended practice is to use a dereferenceable URI, where a persistent copy of this package is available.'
           type: string
           format: uri
-          example: 'https://www.crowncommercial.gov.uk/agreements/RM3733'
+          example: 'https://www.gca.gov.uk/agreements/RM3733'
         version:
           title: OCDS schema version
           description: 'The version of the OCDS schema used in this package, expressed as major.minor For example: 1.0 or 1.1'
@@ -159,7 +159,7 @@ components:
               title: Name
               description: The name of the organization or department responsible for publishing this data.
               type: string
-              example: Crown Commercial Services
+              example: Government Commercial Agency
             scheme:
               title: Scheme
               description: The scheme that holds the unique identifiers used to identify the item being identified.
@@ -178,7 +178,7 @@ components:
               type: string
               nullable: true
               format: uri
-              example: 'https://www.crowncommercial.gov.uk/'
+              example: 'https://www.gca.gov.uk/'
         license:
           title: License
           description: 'A link to the license that applies to the data in this package. A Public Domain Dedication or [Open Definition Conformant](http://opendefinition.org/licenses/) license is recommended. The canonical URI of the license should be used. Documents linked from this file may be under other license conditions.'
@@ -199,7 +199,7 @@ components:
         - type: object
           properties:
             uri:
-              example: 'https://www.crowncommercial.gov.uk/package'
+              example: 'https://www.gca.gov.uk/package'
             version:
               example: '1.0'
             publisher:
@@ -208,15 +208,15 @@ components:
                 - name
               properties:
                 name:
-                  example: Crown Commercial Services
+                  example: Government Commercial Agency
                 scheme:
                   example: XX-CCS
                 uid:
                   example: '123456789'
                 uri:
-                  example: 'https://www.crowncommercial.gov.uk/'
+                  example: 'https://www.gca.gov.uk/'
             publicationPolicy:
-              example: 'https://www.crowncommercial.gov.uk/agreements/publicationPolicy'
+              example: 'https://www.gca.gov.uk/agreements/publicationPolicy'
             publishedDate:
               example: 01/01/2021
             records:
@@ -248,7 +248,7 @@ components:
             - date
           properties:
             url:
-              example: 'https://www.crowncommercial.gov.uk/package/record/release'
+              example: 'https://www.gca.gov.uk/package/record/release'
             date:
               example: 01/01/2020
           

--- a/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml
+++ b/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 
 info:
-  title: CCS Standard Responses
+  title: GCA Standard Responses
   description: Defines the standard HTTP responses expected within CCS.
   version: 0.0.2
 servers:

--- a/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml
+++ b/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml
@@ -59,8 +59,8 @@ components:
       
     ProcurementProjectUri:
       type: string
-      example: api.crowncommercial.org.uk/tenders/projects/123456
-      format: api.crowncommercial.org.uk/tenders/projects/[0-9]+
+      example: api.gca.org.uk/tenders/projects/123456
+      format: api.gca.org.uk/tenders/projects/[0-9]+
       readOnly: true  
       
     ProcurementIdList:
@@ -95,7 +95,7 @@ components:
     Email:
       type: string
       format: email
-      example: support@crowncommercial.org.uk
+      example: support@gca.gov.uk
 
     DetailFlag:
       type: string
@@ -110,7 +110,7 @@ components:
     TermId:
       type: string 
       format: uri
-      example: 'http://agreementservice.crowncommercial.gov.uk/agreements/1234/term/1'
+      example: 'http://agreementservice.gca.gov.uk/agreements/1234/term/1'
   
     Term:
       type: object


### PR DESCRIPTION
These changes are not absolutely essential but will be good to have for the sake of rebranding compliance and future proofing just in case if any API's are planned to be published for good reasons.